### PR TITLE
Update to the en.json file removing {{ }} from datasources_type

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -313,7 +313,7 @@
         "who_can_add": "Who can add to this survey",
         "survey_field": "Survey field",
         "choose_survey_field": "Choose what should be assigned to each survey field",
-        "choose_survey_field_desc": "Each of the survey's fields are listed below. Choose the data from your tweets that you'd like to use to populate each of those fields.",
+        "choose_survey_field_desc": "Each of the survey's fields are listed below. Choose the data from datasource_type your tweets that you'd like to use to populate each of those fields.",  
         "who_can_contribute_to_task" : "Who can contribute to fields in this task",
         "delete" : {
             "desc" : "<strong>If you delete this survey</strong>, all of its posts will also be deleted. Proceed with caution.",


### PR DESCRIPTION
Update to the en.json file removing {{ }} from datasources_type
I tried removing the {{ and }} from the  {{datasource_type}} inorder to make it more readable and understandable

This pull request makes the following changes:
-removes {{ and }} from the word datasource_Type

Testing checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
